### PR TITLE
Added two checks for database initialization and placeholder prints

### DIFF
--- a/ecsopendata/database.py
+++ b/ecsopendata/database.py
@@ -1,8 +1,14 @@
+import os
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
 
-engine = create_engine('sqlite:////tmp/test.db', \
+DATABASE_URL_PREFIX = 'sqlite:///'
+DATABASE_PATH = '/tmp/test.db'
+DATABASE_URL = DATABASE_URL_PREFIX + DATABASE_PATH
+
+engine = create_engine(DATABASE_URL, \
                        convert_unicode=True)
 db_session = scoped_session(sessionmaker(autocommit=False,
                                          autoflush=False,
@@ -11,6 +17,10 @@ Base = declarative_base()
 Base.query = db_session.query_property()
 
 def init_db():
+    if not os.path.exists(DATABASE_PATH):
+        print("Template database will be created")
+        print("call init master table")
+        print("import example data")
     # import all modules here that might define models so that
     # they will be registered properly on the metadata.  Otherwise
     # you will have to import them first before calling init_db()

--- a/ecsopendata/server.py
+++ b/ecsopendata/server.py
@@ -19,7 +19,9 @@ security = Security(app, user_datastore)
 @app.before_first_request
 def create_user():
     init_db()
-    # user_datastore.create_user(email='admin', password='password')
+    if not user_datastore.get_user('admin'):
+        print("creating new 'admin' user with password 'password'")
+        user_datastore.create_user(email='admin', password='password')
     db_session.commit()
 
 # Views


### PR DESCRIPTION
In database.py the init_db checks for the presence of the database
path.  If it doesn't exist, print statements are placeholders for
calling Nicolet5's database population code.

After init_db, a check for an existing user named 'admin' is
performed.  If it returns nothing, a new user is created.